### PR TITLE
chore(ci): add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit top-level `permissions:` blocks to all GitHub Actions workflows to follow the principle of least privilege. This prepares the repository for the upcoming enforcement of read-only `GITHUB_TOKEN` by default across GitHub organizations.

## Permissions Applied

| Workflow | Permission | Reason |
|----------|-----------|--------|
| `ci.yml` | `contents: read` | Only checks out code and runs build — no write access needed |
| `lint.yml` | `contents: read` | Only checks out code and runs linting — no write access needed |
| `deploy.yml` | `contents: write` | Uses `JamesIves/github-pages-deploy-action` which pushes build artifacts to the `gh-pages` branch |

## Context

GitHub is rolling out read-only `GITHUB_TOKEN` as the default for new repositories and will enforce it more broadly. By declaring permissions explicitly now, we:

1. Avoid unexpected breakage when the default changes
2. Follow security best practices (principle of least privilege)
3. Make the required access for each workflow transparent to reviewers